### PR TITLE
[fix] typo shard_id -> shard

### DIFF
--- a/lib/kcl/worker.rb
+++ b/lib/kcl/worker.rb
@@ -270,7 +270,7 @@ module Kcl
           )
           consumer.consume!
         ensure
-          checkpointer.remove_lease_owner(shard_id) # release the shard
+          checkpointer.remove_lease_owner(shard) # release the shard
         end
       end
     end


### PR DESCRIPTION
# What it does do?
- fix typo `shard_id` -> `shard`