### PR TITLE
[~] fix reminder division

### DIFF
--- a/lib/kcl/checkpointer.rb
+++ b/lib/kcl/checkpointer.rb
@@ -189,11 +189,10 @@ module Kcl
       result = @dynamodb.update_item(
         @table_name,
         { DYNAMO_DB_LEASE_PRIMARY_KEY.to_s => shard.shard_id },
-        "remove #{DYNAMO_DB_LEASE_OWNER_KEY}, #{DYNAMO_DB_LEASE_TIMEOUT_KEY}"
+        "remove #{DYNAMO_DB_LEASE_OWNER_KEY}"
       )
       if result
         shard.lease_owner = nil
-        shard.lease_timeout = nil
       else
         Kcl.logger.warn(message: "Failed to remove lease owner for shard", shard: shard.to_h)
       end

--- a/lib/kcl/stats.rb
+++ b/lib/kcl/stats.rb
@@ -1,0 +1,91 @@
+# typed: false
+# frozen_string_literal: true
+
+# deep_dup
+require "active_support"
+require "active_support/core_ext"
+
+module Kcl
+  class Stats
+    class OverprovisionError < StandardError; end
+
+    attr_reader :id, :active_shards, :worker_ids
+
+    def initialize(id:, active_shards:, worker_ids:)
+      @id = id
+      @active_shards = active_shards
+      @worker_ids = worker_ids
+    end
+
+    def current_state
+      @current_state ||= begin
+        result = active_shards.group_by do |_shard_id, shard|
+          shard.potential_owner
+        end
+
+        { id => [], **result.transform_values { |v| v.map(&:first) } }
+      end
+    end
+
+    def desired_state
+      @desired_state ||= current_state.deep_dup
+    end
+
+    def worker_underloaded?(worker_id = id)
+      desired_state[worker_id].count < shards_per_worker + bonus
+    end
+
+    def worker_completed?(worker_id = id)
+      desired_state[worker_id].count <= shards_per_worker
+    end
+
+    def take_shard_from(worker_id, shard_id)
+      shard_to_move = desired_state[worker_id].delete(shard_id)
+      desired_state[id].push(shard_to_move)
+    end
+
+    def shards_per_worker
+      workers_count == 1 ? shards_count : shards_count / workers_count
+    end
+
+    def rebalancing?
+      desired_state != current_state
+    end
+
+    def overprovisioning?
+      workers_count > shards_count
+    end
+
+    def validate!
+      raise OverprovisionError, "Number of workers is greater then number of shards!" if overprovisioning?
+    end
+
+    def bonus
+      # FIRST reminder WORKERS can get +1 shard if there are left some shards due to division
+      worker_ids[0...reminder].include?(id) ? 1 : 0
+    end
+
+    def reminder
+      shards_count - (shards_per_worker * workers_count)
+    end
+
+    def shards_count
+      active_shards.count
+    end
+
+    def workers_count
+      worker_ids.count
+    end
+
+    def to_hash
+      {
+        id: id,
+        current_state: current_state,
+        desired_state: desired_state,
+        workers_count: workers_count,
+        shards_count: shards_count,
+        shards_per_worker: shards_per_worker
+      }
+    end
+  end
+end

--- a/lib/kcl/workers/shard_info.rb
+++ b/lib/kcl/workers/shard_info.rb
@@ -53,6 +53,10 @@ module Kcl
         !lease_timeout || Time.now.utc > lease_timeout_datetime
       end
 
+      def abused?
+        !abendoned?
+      end
+
       def can_be_processed_by?(id)
         # another worker abandoned the shard I got new_owner
         (lease_owner != id && abendoned? && pending_owner == id)

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -24,8 +24,16 @@ RSpec.describe Kcl::Worker, :aggregate_failures do
     Timecop.return
   end
 
-  describe "#perform" do
-    subject { worker.perform }
+  describe "#start" do
+    subject { worker.start }
+
+    before do
+      ENV["DEBUG"] = "true"
+    end
+
+    after do
+      ENV["DEBUG"] = nil
+    end
 
     it do
       expect(worker).to receive(:heartbeat!).ordered
@@ -34,6 +42,7 @@ RSpec.describe Kcl::Worker, :aggregate_failures do
       expect(worker).to receive(:rebalance_shards!).ordered
       expect(worker).to receive(:cleanup_dead_consumers).ordered
       expect(worker).to receive(:consume_shards!).ordered
+      expect(worker).to receive(:cleanup).ordered
 
       subject
     end


### PR DESCRIPTION
# what it does do?
- fix the reminder issue. 8 shards 3 workers -> will be balanced as follows: 1:3, 2:3, 3:2
- Overprovisioning error if you start more workers than shards.
- Refactoring - Stats struct.
- remove lease_owner fix (stuck worker due to wrong timeout value of in-memory shard)