### PR TITLE
[~] increase consumer interval 0.1 -> 0.2

### DIFF
--- a/lib/kcl/workers/consumer.rb
+++ b/lib/kcl/workers/consumer.rb
@@ -35,7 +35,7 @@ module Kcl
           shard_iterator = result[:next_shard_iterator]
           break if !shard_iterator || shard_iterator.empty? || Thread.current[:stop]
 
-          sleep(0.1)
+          sleep(0.2)
         end
 
         shutdown_reason = if shard_iterator.nil?


### PR DESCRIPTION
# What doe the PR do?
the library from time to time can through `Net::OpenTimeout: execution expired` error on `get_records` call.
according to [the documentation](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html):
It is recommended that consumer applications retrieve records via the GetRecords command using the 5 TPS limit to remain caught up.
so I increased the sleep interval between each `get_records` from 0.1 to 0.2