### PR TITLE
Allow using different credentials for DynamoDB and Kinesis clients

### DIFF
--- a/lib/kcl/config.rb
+++ b/lib/kcl/config.rb
@@ -4,11 +4,15 @@
 module Kcl
   class Config
     attr_accessor :dynamodb_endpoint,
+      :dynamodb_credentials,
+      :dynamodb_profile,
       :dynamodb_failover_seconds,
       :dynamodb_read_capacity,
       :dynamodb_table_name,
       :dynamodb_write_capacity,
       :kinesis_endpoint,
+      :kinesis_credentials,
+      :kinesis_profile,
       :kinesis_stream_name,
       :log_level,
       :logger,
@@ -20,11 +24,15 @@ module Kcl
     # Set default values
     def initialize
       @dynamodb_endpoint = nil
+      @dynamodb_credentials = nil
+      @dynamodb_profile = nil
       @dynamodb_failover_seconds = 10
       @dynamodb_read_capacity = 10
       @dynamodb_table_name = nil
       @dynamodb_write_capacity = 10
       @kinesis_endpoint = nil
+      @kinesis_credentials = nil
+      @kinesis_profile = nil
       @kinesis_stream_name = nil
       @logger = nil
       @max_records = 10

--- a/lib/kcl/proxies/dynamo_db_proxy.rb
+++ b/lib/kcl/proxies/dynamo_db_proxy.rb
@@ -11,7 +11,9 @@ module Kcl
       def initialize(config)
         @client = Aws::DynamoDB::Client.new(
           {
-            endpoint: config.dynamodb_endpoint
+              endpoint: config.dynamodb_endpoint,
+              credentials: config.dynamodb_credentials,
+              profile: config.dynamodb_profile
           }.compact
         )
       end

--- a/lib/kcl/proxies/kinesis_proxy.rb
+++ b/lib/kcl/proxies/kinesis_proxy.rb
@@ -11,7 +11,9 @@ module Kcl
       def initialize(config)
         @client = Aws::Kinesis::Client.new(
           {
-            endpoint: config.kinesis_endpoint
+              endpoint: config.kinesis_endpoint,
+              credentials: config.kinesis_credentials,
+              profile: config.kinesis_profile
           }.compact
         )
         @stream_name = config.kinesis_stream_name


### PR DESCRIPTION
Hi!

I would like to propose a change that allows the Kinesis and DynamoDB clients embedded in this KCL consumer library to each use a different set of credentials.

This allows for cross-account stream consumption where the stream and the Dynamo lease table exist in different accounts.

This is similar to AWS' instructions for the official KCL client: https://aws.amazon.com/blogs/architecture/field-notes-how-to-enable-cross-account-access-for-amazon-kinesis-data-streams-using-kinesis-client-library-2-x/

**Setup:**

- Application and DynamoDB lease table exist in account ID 123456789012
- Kinesis stream exists in account ID 987654321098
- Account 123456789012 has a role that allows r/w to Dynamo lease table and allows assuming cross-account stream role via policy:
   ```json
   {
     "Version": "2012-10-17",
     "Statement": {
       "Effect": "Allow",
       "Action": "sts:AssumeRole",
       "Resource": "arn:aws:iam::987654321098:role/KinesisStreamConsumer"
     }
   }
   ```
- Account 987654321098 has a role with arn `arn:aws:iam::987654321098:role/KinesisStreamConsumer` with a policy that allows Kinesis stream reading, and has a trust policy like:
   ```json
   {
     "Version": "2012–10–17",
     "Statement": [
        {
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789012:root"
          },
          "Action": "sts:AssumeRole"
        }
      ]
   }
   ```

**Example:**
```ruby
kinesis_credentials = Aws::AssumeRoleCredentials.new(
  role_arn: "arn:aws:iam::987654321098:role/KinesisStreamConsumer",
  role_session_name: "kcl-consumer"
)

Kcl.configure do |config|
  config.kinesis_credentials: kinesis_credentials
end
```

This snippet above will allow the application to use the ambient credentials (instance profile, default AWS credentials, environment variables, etc) to r/w to the Dynamo state table, and will call `AssumeRole` using the ambient credentials to get access to the cross-account stream consumer role.

Apologies if my Ruby is not great! Please feel free to let me know if there's anything you'd like to see changed or updated.

Thanks!